### PR TITLE
Ensure aria-describedby is set on visible input

### DIFF
--- a/javascript/datepicker-setup.js
+++ b/javascript/datepicker-setup.js
@@ -19,6 +19,11 @@
                 formatted.name = input.name;
                 input.name = formatted.name + '_u';
                 
+                // Ensure the visible input has any aria-describedby attribute
+                if (typeof $(input).attr('aria-describedby') === 'undefined' && typeof $(formatted).attr('aria-describedby') !== 'undefined'){
+                    $(input).attr('aria-describedby', $(formatted).attr('aria-describedby'));
+                }                
+                
                 // Format date for display if returned from server
                 if ($(input).val().trim() !== '') {
                     $(input).val(moment($(input).val()).format(displayFormat));


### PR DESCRIPTION
If aria-described by is set programmatically, it may only be set on the hidden input that contains the reformatted date for submission to the server. Any aria-described by attribute needs to be (at least) on the visible input.